### PR TITLE
DEV-14277 Update READMEs for repo name change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo follows the [terraform standard module structure](https://www.terrafor
 Inline example implementation of the module.  This is the most basic example of what it would look like to use this module.
 ```
 module "rds_postgres" {
-    source = "git::https://github.com/Datatamer/terraform-rds-postgres.git?ref=0.3.0"
+    source = "git::https://github.com/Datatamer/terraform-aws-rds-postgres.git?ref=0.3.0"
     postgres_name = "example_rds_postgres"
     parameter_group_name = "example-rds-postgres-pg"
     identifier_prefix = "example-rds-"

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -1,5 +1,5 @@
 module "rds_postgres" {
-  source               = "git::https://github.com/Datatamer/terraform-rds-postgres.git?ref=0.3.0"
+  source               = "git::https://github.com/Datatamer/terraform-aws-rds-postgres.git?ref=0.3.0"
   postgres_name        = "example_rds_postgres"
   parameter_group_name = "example-rds-postgres-pg"
   identifier_prefix    = "example-rds-"


### PR DESCRIPTION
Changed the repo name from `terraform-rds-postgres` to `terraform-aws-rds-postgres` for [DEV-14277](https://datatamr.atlassian.net/browse/DEV-14277).